### PR TITLE
Use CLI.start instead of CLI.new

### DIFF
--- a/lib/gem_updater/gem_file.rb
+++ b/lib/gem_updater/gem_file.rb
@@ -15,7 +15,7 @@ module GemUpdater
     # Then get new spec set.
     def update!
       puts "Updating gems..."
-      Bundler::CLI.new.update
+      Bundler::CLI.start(['update'])
       @new_spec_set = Bundler.definition.specs
       compute_changes
     end


### PR DESCRIPTION
This fixes an error with using Bundler::CLI.new using the latest version of bundler and closes #4. Thanks and let me know.