### PR TITLE
ADD minimal ruby version

### DIFF
--- a/gem_updater.gemspec
+++ b/gem_updater.gemspec
@@ -10,6 +10,8 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/MaximeD/gem_updater'
   s.license     = 'MIT'
 
+  s.required_ruby_version = '>= 2.0.0'
+
   s.add_runtime_dependency 'bundler',   '~> 1.7'
   s.add_runtime_dependency 'json',      '~> 1.8'
   s.add_runtime_dependency 'nokogiri',  '~> 1.6'


### PR DESCRIPTION
Gemspec is missing the minimal ruby version. This is important since we
are using keywords arguments which is not supported before ruby 2.0

Details:
* ADD required ruby version in gemspec