### PR TITLE
FIX https redirections

### DIFF
--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -38,7 +38,9 @@ module GemUpdater
     # @return [URI] valid URI
     def correct_uri( url )
       uri = URI( url )
-      uri.scheme = 'https' if uri.host == 'github.com' && uri.scheme == 'http'
+      if uri.host == 'github.com' && uri.scheme == 'http'
+        uri = URI url.gsub( %r((http)(://github.com)), '\1s\2' )
+      end
 
       uri
     end


### PR DESCRIPTION
Some gems are reported to be hosted on `http://github.com` rather than
the `https` version of github. This leads to a redirection which is not
handled by `open-uri`.
Since updating `scheme` after uri creation does not seem to work
anymore, check url before converting is to an `URI`.

Details
* FIX url conversion to `https`