### PR TITLE
ADD support for other sources

### DIFF
--- a/lib/gem_updater/gem_file.rb
+++ b/lib/gem_updater/gem_file.rb
@@ -5,30 +5,54 @@ module GemUpdater
   # GemFile is responsible for handling `Gemfile`
   class GemFile
     attr_accessor :changes
+    attr_reader :old_spec_set, :new_spec_set
 
     def initialize
-      @old_spec_set = Bundler.definition.specs
-      @changes      = {}
+      @changes = {}
     end
 
     # Run `bundle update` to update gems.
-    # Then get new spec set.
     def update!
       puts "Updating gems..."
       Bundler::CLI.start( [ 'update' ] )
-      @new_spec_set = Bundler.definition.specs
-      compute_changes
     end
 
     # Compute the diffs between two `Gemfile.lock`.
     #
     # @return [Hash] gems for which there are differences.
     def compute_changes
-      @old_spec_set.each do |gem_specs|
-        unless ( old_version = gem_specs.version ) == ( new_version = @new_spec_set[ gem_specs.name ].first.version )
-          @changes[ gem_specs.name ] = { versions: { old: old_version.to_s, new: new_version.to_s } }
+      get_spec_sets
+
+      old_spec_set.each do |old_gem|
+        if updated_gem = new_spec_set.find{ |new_gem| new_gem.name == old_gem.name }
+          unless old_gem.version == updated_gem.version
+            changes[ old_gem.name ] = { versions: { old: old_gem.version.to_s, new: updated_gem.version.to_s }, source: updated_gem.source }
+          end
         end
       end
+    end
+
+    private
+
+    # Get the two spec sets (before and after `bundle update`)
+    def get_spec_sets
+      @old_spec_set = spec_set
+      reinitialize_spec_set!
+      @new_spec_set = spec_set
+    end
+
+    # Get the current spec set
+    #
+    # @return [Array] array of Bundler::LazySpecification (including gem name, version and source)
+    def spec_set
+      Bundler.locked_gems.specs
+    end
+
+    # Calling `Bundler.locked_gems` before or after a `bundler update`
+    # will return the same result.
+    # Use a hacky way to tell bundle we want to parse the new `Gemfile.lock`
+    def reinitialize_spec_set!
+      Bundler.remove_instance_variable( "@locked_gems" )
     end
   end
 end

--- a/lib/gem_updater/ruby_gems_fetcher.rb
+++ b/lib/gem_updater/ruby_gems_fetcher.rb
@@ -6,29 +6,78 @@ module GemUpdater
 
   # RubyGemsFetcher is a wrapper around rubygems API.
   class RubyGemsFetcher
+    attr_reader :gem_name, :source
 
     # @param gem_name [String] name of the gem
-    def initialize( gem_name )
+    # @param source [Bundler::Source] source of gem
+    def initialize( gem_name, source )
       @gem_name = gem_name
+      @source   = source
     end
 
     # Finds where code is hosted.
-    # Most likely in will be in 'source_code_uri' or 'homepage_uri'
+    # Most likely in will be on rubygems, else look in other sources.
     #
-    # @return [String] url of gem source code
+    # @return [String|nil] url of gem source code
     def source_uri
-      information[ "source_code_uri" ] || information[ "homepage_uri" ]
+      uri_from_rubygems || uri_from_other_sources
     end
 
     private
 
-    # Obtain information about a given gem
-    # from rubygems.org.
+    # Ask rubygems.org for source uri of gem.
     # See API: http://guides.rubygems.org/rubygems-org-api/#gem-methods
     #
-    # @return [Hash] parse of json information
-    def information
-      @information ||= JSON.parse( open( "https://rubygems.org/api/v1/gems/#{@gem_name}.json" ).read )
+    # @return [String|nil] uri of source code
+    def uri_from_rubygems
+      return unless source.remotes.map( &:host ).include?( 'rubygems.org' )
+
+      response = begin
+        JSON.parse( open( "https://rubygems.org/api/v1/gems/#{gem_name}.json" ).read )
+      rescue OpenURI::HTTPError
+      end
+
+      if response
+        response[ "source_code_uri" ] || response[ "homepage_uri" ]
+      end
+    end
+
+    # Look if gem can be found in another remote
+    #
+    # @return [String|nil] uri of source code
+    def uri_from_other_sources
+      uri = nil
+      source.remotes.each do |remote|
+        break if uri
+
+        uri = case remote.host
+              when 'rubygems.org' then next # already checked
+              when 'rails-assets.org'
+                uri_from_railsassets
+              else
+                puts "Source #{remote} is not supported, feel free to open a PR or an issue on https://github.com/MaximeD/gem_updater"
+              end
+      end
+
+      uri
+    end
+
+    # Ask rails-assets.org for source uri of gem.
+    # API is at : https://rails-assets.org/packages/package_name
+    #
+    # @return [String|nil] uri of source code
+    def uri_from_railsassets
+      begin
+        response = JSON.parse( open( "https://rails-assets.org/packages/#{gem_name.gsub( /rails-assets-/, '' )}" ).read )
+      rescue JSON::ParserError
+        # if gem is not found, rails-assets returns a 200
+        # with html (instead of json) containing a 500...
+      rescue OpenURI::HTTPError
+      end
+
+      if response
+        response[ "url" ].gsub( /^git/, 'http' )
+      end
     end
   end
 end

--- a/spec/gem_updater/ruby_gems_fetcher_spec.rb
+++ b/spec/gem_updater/ruby_gems_fetcher_spec.rb
@@ -1,50 +1,109 @@
 require 'spec_helper'
 
 describe GemUpdater::RubyGemsFetcher do
-  subject { GemUpdater::RubyGemsFetcher.new( 'gem_name' ) }
+  subject { GemUpdater::RubyGemsFetcher.new( 'gem_name', OpenStruct.new( remotes: [ URI( 'https://rubygems.org' ) ] ) ) }
 
   describe '#source_uri' do
-    context "when 'source_code_uri' is present" do
-      before do
-        allow( subject ).to receive_message_chain( :open, :read ) { { source_code_uri: 'source_code_uri' }.to_json }
-        subject.source_uri
+    context 'when gem exists on rubygems.org' do
+      context "when 'source_code_uri' is present" do
+        before do
+          allow( subject ).to receive_message_chain( :open, :read ) { { source_code_uri: 'source_code_uri' }.to_json }
+          subject.source_uri
+        end
+
+        it "returns 'source_code_uri' value" do
+          expect( subject.source_uri ).to eq 'source_code_uri'
+        end
       end
 
-      it "returns 'source_code_uri' value" do
-        expect( subject.source_uri ).to eq 'source_code_uri'
+      context "when 'homepage_uri' is present" do
+        before do
+          allow( subject ).to receive_message_chain( :open, :read ) { { homepage_uri: 'homepage_uri' }.to_json }
+          subject.source_uri
+        end
+
+        it "returns 'homepage_uri' value" do
+          expect( subject.source_uri ).to eq 'homepage_uri'
+        end
+      end
+
+      context "when both 'source_code_uri' and 'homepage_uri' are present" do
+        before do
+          allow( subject ).to receive_message_chain( :open, :read ) { { source_code_uri: 'source_code_uri', homepage_uri: 'homepage_uri' }.to_json }
+          subject.source_uri
+        end
+
+        it "returns 'source_code_uri' value" do
+          expect( subject.source_uri ).to eq 'source_code_uri'
+        end
+      end
+
+      context 'none is present' do
+        before do
+          allow( subject ).to receive_message_chain( :open, :read ) { {}.to_json }
+          allow( subject ).to receive( :uri_from_other_sources )
+          subject.source_uri
+        end
+
+        it 'looks in other sources' do
+          expect( subject ).to have_received( :uri_from_other_sources )
+        end
       end
     end
 
-    context "when 'homepage_uri' is present" do
-      before do
-        allow( subject ).to receive_message_chain( :open, :read ) { { homepage_uri: 'homepage_uri' }.to_json }
-        subject.source_uri
+    context 'when gem does not exists on rubygems.org' do
+      context 'when they are no other hosts' do
+        before :each do
+          allow( subject ).to receive( :uri_from_rubygems ) { nil }
+        end
+
+        it 'returns nil' do
+          expect( subject.source_uri ).to be_nil
+        end
       end
 
-      it "returns 'homepage_uri' value" do
-        expect( subject.source_uri ).to eq 'homepage_uri'
-      end
-    end
+      context 'when they are other hosts' do
+        before :each do
+          allow( subject ).to receive( :uri_from_rubygems ) { nil }
+        end
 
-    context "when both 'source_code_uri' and 'homepage_uri' are present" do
-      before do
-        allow( subject ).to receive_message_chain( :open, :read ) { { source_code_uri: 'source_code_uri', homepage_uri: 'homepage_uri' }.to_json }
-        subject.source_uri
-      end
+        describe 'looking on rubygems' do
+          before :each do
+            allow( subject.source ).to receive( :remotes ) { [ URI( 'https://rubygems.org' ), URI( '' ) ] }
+            allow( subject ).to receive( :uri_from_other_sources ) { nil }
+            subject.source_uri
+          end
 
-      it "returns 'source_code_uri' value" do
-        expect( subject.source_uri ).to eq 'source_code_uri'
-      end
-    end
+          it 'does it only once' do
+            expect( subject ).to have_received( :uri_from_rubygems ).once
+          end
+        end
 
-    context 'none is present' do
-      before do
-        allow( subject ).to receive_message_chain( :open, :read ) { {}.to_json }
-        subject.source_uri
-      end
+        context 'when gem can be hosted on rails-assets.org' do
+          before :each do
+            allow( subject.source ).to receive( :remotes ) { [ URI( 'https://rubygems.org' ), URI( 'https://rails-assets.org' ) ] }
+          end
 
-      it 'is falsey' do
-        expect( subject.source_uri ).to be_falsey
+          context 'when gem is on rails-assets' do
+            before :each do
+              allow( subject ).to receive_message_chain( :open, :read ) { { url: 'git://fake.com/gem_name' }.to_json }
+            end
+
+            it 'returns http url' do
+              expect( subject.source_uri ).to eq 'http://fake.com/gem_name'
+            end
+          end
+
+          context 'when gem is not on rails-assets' do
+            before :each do
+              allow( subject ).to receive_message_chain( :open, :read ) { "<title>We're sorry, but something went wrong (500)</title>" }
+            end
+
+            it 'returns nil' do
+              expect( subject.source_uri ).to be_nil
+            end
+          end
+        end
       end
     end
   end

--- a/spec/gem_updater_spec.rb
+++ b/spec/gem_updater_spec.rb
@@ -1,7 +1,14 @@
 require 'spec_helper'
 
 describe GemUpdater::Updater do
-  let( :gemfile ){ OpenStruct.new( update!: true, changes: [] ) }
+  let( :gemfile ) do
+    OpenStruct.new(
+      update!:          ->{},
+      changes:          { fake_gem: { versions: { old: '0.1', new: '0.2' } } },
+      compute_changes:  ->{},
+      find_source:      ->{}
+    )
+  end
 
   before :each do
     allow( GemUpdater::GemFile ).to receive( :new ).and_return( gemfile )
@@ -10,14 +17,18 @@ describe GemUpdater::Updater do
   describe '#update' do
     before :each do
       allow( gemfile ).to receive( :update! )
-      allow( gemfile ).to receive( :changes ).and_return( { fake_gem: { versions: { old: '0.1', new: '0.2' } } } )
-      allow( GemUpdater::RubyGemsFetcher ).to receive_message_chain( :new, :source_uri )
-      allow( GemUpdater::SourcePageParser ).to receive( :new ).and_return( @source_page = OpenStruct.new( changelog: 'fake_gem_changelog_url' ) )
+      allow( gemfile ).to receive( :compute_changes )
+      allow( subject ).to receive( :find_source )               { 'fake_gem_changelog_url' }
+      allow( GemUpdater::SourcePageParser ).to receive( :new )  { OpenStruct.new( changelog: 'fake_gem_changelog_url' ) }
       subject.update!
     end
 
     it 'updates gemfile' do
       expect( gemfile ).to have_received( :update! )
+    end
+
+    it 'computes changes' do
+      expect( gemfile ).to have_received( :compute_changes )
     end
 
     it 'gets changelogs' do
@@ -49,6 +60,35 @@ CHANGELOG
 
 CHANGELOG
       )
+    end
+  end
+
+
+  describe '#find_source' do
+    context 'when it is Bundler::Source::Rubygems' do
+      let( :ruby_gems_fetcher ) { OpenStruct.new( source_uri: 'fake_gem_url' ) }
+
+      before :each do
+        allow( ruby_gems_fetcher ).to receive( :source_uri )
+        allow( GemUpdater::RubyGemsFetcher ).to receive( :new ) { ruby_gems_fetcher }
+        subject.send( :find_source, 'fake_gem', Bundler::Source::Rubygems.new )
+      end
+
+      it 'delegates to RubyGems fetcher' do
+        expect( ruby_gems_fetcher ).to have_received( :source_uri )
+      end
+    end
+
+    context 'when it is Bundler::Source::Git' do
+      let( :git_source ) { OpenStruct.new( uri: 'git://fakeurl.com/gem.git' ) }
+
+      before :each do
+        allow( Bundler::Source::Git ).to receive( :=== ) { true }
+      end
+
+      it 'returns git url converted to http url' do
+        expect( subject.send( :find_source, 'fake_gem', git_source ) ).to eq 'http://fakeurl.com/gem'
+      end
     end
   end
 end


### PR DESCRIPTION
For now, `gem_updater` only supports gems hosted on `rubygems.org`,
problem is if user want another source (like `rails-assets.org`), gem
will crash.
Moreover, if a dependant gem has been removed from a new version,
another crash will happen since it considers old gems should always be
part of new ones.

Related #12
Related #13

Details
* REFACTOR to use `Bundler.locked_gems.specs`
* ADD support for other sources (only `rails-assets` for now)
* ADD support for `git` source
* UPDATE doc
* UPDATE specs