### PR TITLE
ADD auto-commit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,16 @@ gem_update
 <copy paste of output to commit message>
 ```
 
+If you prefer to, you can ask gem_update to commit straight away:
+
+```
+gem_update --commit
+```
+
+This will use the generated message as a commit message template, allowing you
+to edit before commit.
+
+
 ### Diff format
 
 By default, diff for your gems will look like the following:

--- a/bin/gem_update
+++ b/bin/gem_update
@@ -8,6 +8,19 @@ require 'gem_updater'
 gems = GemUpdater::Updater.new
 gems.update!
 
-puts "\nHere are your changes:"
-puts '------------------------'
-gems.format_diff
+if ARGV.include? '--commit'
+  require 'tempfile'
+  file = Tempfile.new( 'gem_updater' )
+  file.write "UPDATE gems\n\n"
+  file.write gems.format_diff.join
+  file.close
+
+  gemfile = Bundler.default_gemfile.to_s
+
+  system %(git add #{gemfile} #{gemfile}.lock && git commit -t #{file.path} --allow-empty-message)
+  file.unlink
+else
+  puts "\nHere are your changes:"
+  puts '------------------------'
+  gems.output_diff
+end

--- a/lib/gem_updater.rb
+++ b/lib/gem_updater.rb
@@ -31,11 +31,16 @@ module GemUpdater
       end
     end
 
+    # Print formatted diff
+    def output_diff
+      puts format_diff.join( "\n" )
+    end
+
     # Format the diff to get human readable information
     # on the gems that were updated.
     def format_diff
-      gemfile.changes.each do |gem, details|
-        puts ERB.new( template, nil, '<>' ).result( binding )
+      gemfile.changes.map do |gem, details|
+        ERB.new( template, nil, '<>' ).result( binding )
       end
     end
 

--- a/spec/gem_updater_spec.rb
+++ b/spec/gem_updater_spec.rb
@@ -36,14 +36,14 @@ describe GemUpdater::Updater do
     end
   end
 
-  describe '#format_diff' do
+  describe '#output_diff' do
     before :each do
       allow( gemfile ).to receive( :changes ).and_return( {
         fake_gem_1: { changelog: 'fake_gem_1_url', versions: { old: '1.0', new: '1.1' } },
         fake_gem_2: { changelog: 'fake_gem_2_url', versions: { old: '0.4', new: '0.4.2' } }
       } )
       allow( STDOUT ).to receive( :puts )
-      subject.format_diff
+      subject.output_diff
     end
 
     it 'outputs changes' do
@@ -51,15 +51,29 @@ describe GemUpdater::Updater do
 * fake_gem_1 1.0 → 1.1
 [changelog](fake_gem_1_url)
 
-CHANGELOG
-      )
 
-      expect( STDOUT ).to have_received( :puts ).with( <<CHANGELOG
 * fake_gem_2 0.4 → 0.4.2
 [changelog](fake_gem_2_url)
 
 CHANGELOG
       )
+
+    end
+  end
+
+
+  describe '#format_diff' do
+    before :each do
+      allow( gemfile ).to receive( :changes ).and_return( {
+        fake_gem_1: { changelog: 'fake_gem_1_url', versions: { old: '1.0', new: '1.1' } },
+        fake_gem_2: { changelog: 'fake_gem_2_url', versions: { old: '0.4', new: '0.4.2' } }
+      } )
+    end
+
+    it 'contains changes' do
+      [ "* fake_gem_1 1.0 → 1.1\n[changelog](fake_gem_1_url)\n\n", "* fake_gem_2 0.4 → 0.4.2\n[changelog](fake_gem_2_url)\n\n" ].each do |msg|
+        expect( subject.format_diff ).to include msg
+      end
     end
   end
 


### PR DESCRIPTION
When passed `--commit` option, gem_update will automatically create a
commit message using the generated diff.

User will be given a chance to edit message before committing. Note that
to allow that, git commit's `-t` option has been used. While it's cool
because it allows both to provide a message and to edit it, it has a
limitation: unmodified message will result in cancelled commit.

To fix that, `--allow-empty-message` has been added. It has problems of
its own: user can't cancel commit manually. It's still possible to
reverse commit if really that was not wanted (after all, user
explicitely asked for it).

It won't be any trouble if there was nothing to update, in case you
wonder: git will see there's nothing to commit and won't even open the
editor.