### PR TITLE
ADD clever load path

### DIFF
--- a/bin/gem_update
+++ b/bin/gem_update
@@ -3,6 +3,7 @@
 # Exit cleanly from an early interrupt
 Signal.trap("INT") { exit 1 }
 
+$:.unshift File.expand_path( '../../lib', __FILE__ )
 require 'gem_updater'
 
 gems = GemUpdater::Updater.new


### PR DESCRIPTION
When using `gem_update` locally, it falls back to requiring official
rubygems version, which is quite painful for local dev.
The best would be for it to use the version from where it is called,
which is handled by updating load path.

Details
* ADD a clever load path