### PR TITLE
FIX redirections on github subdomains

### DIFF
--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -38,8 +38,8 @@ module GemUpdater
     # @return [URI] valid URI
     def correct_uri( url )
       uri = URI( url )
-      if uri.host == 'github.com' && uri.scheme == 'http'
-        uri = URI url.gsub( %r((http)(://github.com)), '\1s\2' )
+      if uri.host.match( 'github.com' ) && uri.scheme == 'http'
+        uri = URI "https://github.com#{uri.path}"
       end
 
       uri

--- a/spec/gem_updater/source_page_parser_spec.rb
+++ b/spec/gem_updater/source_page_parser_spec.rb
@@ -37,4 +37,34 @@ describe GemUpdater::SourcePageParser do
       end
     end
   end
+
+  describe '#initialize' do
+    context 'when url is standard' do
+      it 'returns it' do
+        expect( GemUpdater::SourcePageParser.new( url: 'http://example.com', version: 1 ).instance_variable_get :@uri ).to eq URI( 'http://example.com' )
+      end
+    end
+
+    context 'when url is on github' do
+      context 'when url is https' do
+        it 'returns it' do
+          expect( GemUpdater::SourcePageParser.new( url: 'https://github.com/fake_user/fake_gem', version: 1 ).instance_variable_get :@uri ).to eq URI( 'https://github.com/fake_user/fake_gem' )
+        end
+      end
+
+      context 'when url is http' do
+        context 'when url host is github' do
+          it 'returns https version of it' do
+            expect( GemUpdater::SourcePageParser.new( url: 'http://github.com/fake_user/fake_gem', version: 1 ).instance_variable_get :@uri ).to eq URI( 'https://github.com/fake_user/fake_gem' )
+          end
+
+          context 'when url host is a subdomain of github' do
+            it 'returns https version of base domain' do
+              expect( GemUpdater::SourcePageParser.new( url: 'http://wiki.github.com/fake_user/fake_gem', version: 1 ).instance_variable_get :@uri ).to eq URI( 'https://github.com/fake_user/fake_gem' )
+            end
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Some gems report their homepage to be on github subdomains like
`wiki.github.com`. When this is reported to be the non ssl version of
github, secure redirection will not occur.

Related #18

Details
* FIX redirections on github subdomains
* ADD specs