### PR TITLE
FIX redirections of bitbucket

### DIFF
--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -38,8 +38,14 @@ module GemUpdater
     # @return [URI] valid URI
     def correct_uri( url )
       uri = URI( url )
-      if uri.host.match( 'github.com' ) && uri.scheme == 'http'
-        uri = URI "https://github.com#{uri.path}"
+      if uri.scheme == 'http'
+        case
+        when uri.host.match( 'github.com' )
+          # remove possible subdomain like 'wiki.github.com'
+          uri = URI "https://github.com#{uri.path}"
+        when uri.host.match( 'bitbucket.org' )
+          uri = URI "https://#{uri.host}#{uri.path}"
+        end
       end
 
       uri

--- a/spec/gem_updater/source_page_parser_spec.rb
+++ b/spec/gem_updater/source_page_parser_spec.rb
@@ -53,16 +53,28 @@ describe GemUpdater::SourcePageParser do
       end
 
       context 'when url is http' do
-        context 'when url host is github' do
-          it 'returns https version of it' do
-            expect( GemUpdater::SourcePageParser.new( url: 'http://github.com/fake_user/fake_gem', version: 1 ).instance_variable_get :@uri ).to eq URI( 'https://github.com/fake_user/fake_gem' )
-          end
+        it 'returns https version of it' do
+          expect( GemUpdater::SourcePageParser.new( url: 'http://github.com/fake_user/fake_gem', version: 1 ).instance_variable_get :@uri ).to eq URI( 'https://github.com/fake_user/fake_gem' )
+        end
 
-          context 'when url host is a subdomain of github' do
-            it 'returns https version of base domain' do
-              expect( GemUpdater::SourcePageParser.new( url: 'http://wiki.github.com/fake_user/fake_gem', version: 1 ).instance_variable_get :@uri ).to eq URI( 'https://github.com/fake_user/fake_gem' )
-            end
+        context 'when url host is a subdomain' do
+          it 'returns https version of base domain' do
+            expect( GemUpdater::SourcePageParser.new( url: 'http://wiki.github.com/fake_user/fake_gem', version: 1 ).instance_variable_get :@uri ).to eq URI( 'https://github.com/fake_user/fake_gem' )
           end
+        end
+      end
+    end
+
+    context 'when url is on bitbucket' do
+      context 'when url is https' do
+        it 'returns it' do
+          expect( GemUpdater::SourcePageParser.new( url: 'https://bitbucket.org/fake_user/fake_gem', version: 1 ).instance_variable_get :@uri ).to eq URI( 'https://bitbucket.org/fake_user/fake_gem' )
+        end
+      end
+
+      context 'when url is http' do
+        it 'returns https version of it' do
+          expect( GemUpdater::SourcePageParser.new( url: 'http://bitbucket.org/fake_user/fake_gem', version: 1 ).instance_variable_get :@uri ).to eq URI( 'https://bitbucket.org/fake_user/fake_gem' )
         end
       end
     end


### PR DESCRIPTION
We can have some links pointing to non ssl version of bitbucket, leading
`open-uri` to crash (just like it would with github).

Related #24

Details

* FIX redirections on bitbucket.org
* ADD specs