### PR TITLE
UPDATE allow to update only specified gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# master
+
+Add ability to update only a given set of gems (just as bundler does).
+
+```
+gem_update gem1 gem2
+```
+
+Enhancement:
+* allow to update only given gems
+
 # 0.3.2 (July 23, 2015)
 
 Fix:

--- a/bin/gem_update
+++ b/bin/gem_update
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'optparse'
 
 # Exit cleanly from an early interrupt
 Signal.trap("INT") { exit 1 }
@@ -6,11 +7,18 @@ Signal.trap("INT") { exit 1 }
 $:.unshift File.expand_path( '../../lib', __FILE__ )
 require 'gem_updater'
 
+options = {}
+OptionParser.new do |opts|
+  opts.on( "-c", "--commit", "Auto commit" ) do |v|
+    options[ :commit ] = v
+  end
+end.parse!
+
 gems = GemUpdater::Updater.new
-gems.update!
+gems.update!( ARGV )
 
 if gems.gemfile.changes.any?
-  if ARGV.include? '--commit'
+  if options[ :commit ]
     require 'tempfile'
     file = Tempfile.new( 'gem_updater' )
     file.write "UPDATE gems\n\n"

--- a/lib/gem_updater.rb
+++ b/lib/gem_updater.rb
@@ -17,10 +17,11 @@ module GemUpdater
     # This will:
     #   1. update gemfile
     #   2. find changelogs for updated gems
-    def update!
-      gemfile.update!
+    #
+    # @param gems [Array] list of gems to update
+    def update!( gems )
+      gemfile.update!( gems )
       gemfile.compute_changes
-
 
       gemfile.changes.each do |gem_name, details|
         if source_uri = find_source( gem_name, details[ :source ] )

--- a/lib/gem_updater/gem_file.rb
+++ b/lib/gem_updater/gem_file.rb
@@ -12,9 +12,9 @@ module GemUpdater
     end
 
     # Run `bundle update` to update gems.
-    def update!
+    def update!( gems )
       puts "Updating gems..."
-      Bundler::CLI.start( [ 'update' ] )
+      Bundler::CLI.start( [ 'update' ] + gems )
     end
 
     # Compute the diffs between two `Gemfile.lock`.

--- a/spec/gem_updater/gem_file_spec.rb
+++ b/spec/gem_updater/gem_file_spec.rb
@@ -24,7 +24,7 @@ describe GemUpdater::GemFile do
   describe '#update!' do
     before :each do
       allow( subject ).to receive( :compute_changes )
-      subject.update!
+      subject.update!( [] )
     end
 
     it 'launches bundle update' do

--- a/spec/gem_updater_spec.rb
+++ b/spec/gem_updater_spec.rb
@@ -2,25 +2,24 @@ require 'spec_helper'
 
 describe GemUpdater::Updater do
   let( :gemfile ) do
-    OpenStruct.new(
-      update!:          ->{},
-      changes:          { fake_gem: { versions: { old: '0.1', new: '0.2' } } },
-      compute_changes:  ->{},
-      find_source:      ->{}
-    )
+    instance_double( GemUpdater::GemFile, changes: { fake_gem: { versions: { old: '0.1', new: '0.2' } } } )
+  end
+
+  let( :source_page_parser ) do
+    instance_double( GemUpdater::SourcePageParser, changelog: 'fake_gem_changelog_url' )
   end
 
   before :each do
     allow( GemUpdater::GemFile ).to receive( :new ).and_return( gemfile )
+    allow( GemUpdater::SourcePageParser ).to receive( :new ).and_return( source_page_parser )
   end
 
   describe '#update' do
     before :each do
       allow( gemfile ).to receive( :update! )
       allow( gemfile ).to receive( :compute_changes )
-      allow( subject ).to receive( :find_source )               { 'fake_gem_changelog_url' }
-      allow( GemUpdater::SourcePageParser ).to receive( :new )  { OpenStruct.new( changelog: 'fake_gem_changelog_url' ) }
-      subject.update!
+      allow( subject ).to receive( :find_source )     { 'fake_gem_changelog_url' }
+      subject.update!( [] )
     end
 
     it 'updates gemfile' do
@@ -38,10 +37,10 @@ describe GemUpdater::Updater do
 
   describe '#output_diff' do
     before :each do
-      allow( gemfile ).to receive( :changes ).and_return( {
-        fake_gem_1: { changelog: 'fake_gem_1_url', versions: { old: '1.0', new: '1.1' } },
-        fake_gem_2: { changelog: 'fake_gem_2_url', versions: { old: '0.4', new: '0.4.2' } }
-      } )
+      allow( gemfile ).to receive( :changes ) do
+        { fake_gem_1: { changelog: 'fake_gem_1_url', versions: { old: '1.0', new: '1.1' } },
+        fake_gem_2: { changelog: 'fake_gem_2_url', versions: { old: '0.4', new: '0.4.2' } } }
+      end
       allow( STDOUT ).to receive( :puts )
       subject.output_diff
     end
@@ -64,10 +63,10 @@ CHANGELOG
 
   describe '#format_diff' do
     before :each do
-      allow( gemfile ).to receive( :changes ).and_return( {
-        fake_gem_1: { changelog: 'fake_gem_1_url', versions: { old: '1.0', new: '1.1' } },
-        fake_gem_2: { changelog: 'fake_gem_2_url', versions: { old: '0.4', new: '0.4.2' } }
-      } )
+      allow( gemfile ).to receive( :changes ) do
+        { fake_gem_1: { changelog: 'fake_gem_1_url', versions: { old: '1.0', new: '1.1' } },
+        fake_gem_2: { changelog: 'fake_gem_2_url', versions: { old: '0.4', new: '0.4.2' } } }
+      end
     end
 
     it 'contains changes' do


### PR DESCRIPTION
Bundle allows to update only given gems instead of the whole `Gemfile`.
This is done by passing gems names as arguments: `bundle update foo
bar`. `gem_updater` should mimic that behaviour.

Related #1

Details

* REFACTOR binary to use `optparse`
* UPDATE allow passing list of gems to update
* UPDATE specs