### PR TITLE
REFACTOR logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ gem_update gem1 gem2
 
 Enhancement:
 * allow to update only given gems
+* refactor logger (use `Bundler.ui`)
 
 # 0.3.2 (July 23, 2015)
 

--- a/bin/gem_update
+++ b/bin/gem_update
@@ -7,6 +7,8 @@ Signal.trap("INT") { exit 1 }
 $:.unshift File.expand_path( '../../lib', __FILE__ )
 require 'gem_updater'
 
+Bundler.ui = Bundler::UI::Shell.new
+
 options = {}
 OptionParser.new do |opts|
   opts.on( "-c", "--commit", "Auto commit" ) do |v|
@@ -30,10 +32,10 @@ if gems.gemfile.changes.any?
     system %(git add #{gemfile} #{gemfile}.lock && git commit -t #{file.path} --allow-empty-message)
     file.unlink
   else
-    puts "\nHere are your changes:"
-    puts '------------------------'
+    Bundler.ui.confirm "\nHere are your changes:"
+    Bundler.ui.confirm '------------------------'
     gems.output_diff
   end
 else
-  puts "\nCongratulations, your Gemfile was already up-to-date!"
+  Bundler.ui.confirm "\nCongratulations, your Gemfile was already up-to-date!"
 end

--- a/lib/gem_updater.rb
+++ b/lib/gem_updater.rb
@@ -34,7 +34,7 @@ module GemUpdater
 
     # Print formatted diff
     def output_diff
-      puts format_diff.join( "\n" )
+      Bundler.ui.info format_diff.join
     end
 
     # Format the diff to get human readable information

--- a/lib/gem_updater/gem_file.rb
+++ b/lib/gem_updater/gem_file.rb
@@ -13,7 +13,7 @@ module GemUpdater
 
     # Run `bundle update` to update gems.
     def update!( gems )
-      puts "Updating gems..."
+      Bundler.ui.warn "Updating gems..."
       Bundler::CLI.start( [ 'update' ] + gems )
     end
 

--- a/lib/gem_updater/ruby_gems_fetcher.rb
+++ b/lib/gem_updater/ruby_gems_fetcher.rb
@@ -55,7 +55,7 @@ module GemUpdater
               when 'rails-assets.org'
                 uri_from_railsassets
               else
-                puts "Source #{remote} is not supported, feel free to open a PR or an issue on https://github.com/MaximeD/gem_updater"
+                Bundler.ui.error "Source #{remote} is not supported, feel free to open a PR or an issue on https://github.com/MaximeD/gem_updater"
               end
       end
 

--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -19,15 +19,15 @@ module GemUpdater
     # @return [String, nil] URL of changelog
     def changelog
       @changelog ||= begin
-        puts "Looking for a changelog in #{@uri}"
+        Bundler.ui.warn "Looking for a changelog in #{@uri}"
         doc = Nokogiri::HTML( open( @uri ) )
 
         find_changelog( doc )
 
       rescue OpenURI::HTTPError # Uri points to nothing
-        puts "Cannot find #{@uri}"
+        Bundler.ui.error "Cannot find #{@uri}"
       rescue Errno::ETIMEDOUT # timeout
-        puts "#{@uri} is down"
+        Bundler.ui.error "#{@uri} is down"
       end
     end
 

--- a/spec/gem_updater_spec.rb
+++ b/spec/gem_updater_spec.rb
@@ -41,22 +41,20 @@ describe GemUpdater::Updater do
         { fake_gem_1: { changelog: 'fake_gem_1_url', versions: { old: '1.0', new: '1.1' } },
         fake_gem_2: { changelog: 'fake_gem_2_url', versions: { old: '0.4', new: '0.4.2' } } }
       end
-      allow( STDOUT ).to receive( :puts )
+      allow( Bundler.ui ).to receive( :info )
       subject.output_diff
     end
 
     it 'outputs changes' do
-      expect( STDOUT ).to have_received( :puts ).with( <<CHANGELOG
+      expect( Bundler.ui ).to have_received( :info ).with( <<CHANGELOG
 * fake_gem_1 1.0 → 1.1
 [changelog](fake_gem_1_url)
-
 
 * fake_gem_2 0.4 → 0.4.2
 [changelog](fake_gem_2_url)
 
 CHANGELOG
       )
-
     end
   end
 


### PR DESCRIPTION
All logs are made with `puts`.
Well it would be better to use a dedicated one, and since `bundler`
vendors one (through `thor`), we can use this one.

Details

* REFACTOR use `Bundler.ui`
* UPDATE specs