### PR TITLE
ADD multithreading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ gem_update gem1 gem2
 Enhancement:
 * allow to update only given gems
 * refactor logger (use `Bundler.ui`)
+* add multithreading
 
 # 0.3.2 (July 23, 2015)
 


### PR DESCRIPTION
For each updated gem, the process is the same:
looking for it's changelog over the internet.
So for each of them we issue http requests, wait for them to complete,
and once one is over, we proceed to next gem.
This should be multithreaded to gain some time.

Details

* ADD multithreading