### PR TITLE
FIX return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master (unreleased)
+
+Fix:
+* when changelog is not found, it may return an object instead of nothing
+
 # 0.4.0 (July 25, 2015)
 
 You can now update only a set of gems (just as bundler does).

--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -26,8 +26,10 @@ module GemUpdater
 
       rescue OpenURI::HTTPError # Uri points to nothing
         Bundler.ui.error "Cannot find #{@uri}"
+        false
       rescue Errno::ETIMEDOUT # timeout
         Bundler.ui.error "#{@uri} is down"
+        false
       end
     end
 


### PR DESCRIPTION
Switching to bundler logger (#32) changed the return value of
memoized function to fetch changelog. As a consequence when it logs an
error it returns the bundler logger instead of returning nil. So
it displays that changelog link is an object whand it should be nil.

Details

* FIX return value when error