### PR TITLE
ADD support for textile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Enhancement:
 * add recognition of `Changes` as a changelog
+* add support of `textile` files
 
 # 0.4.1 (August 11, 2015)
 

--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -81,7 +81,7 @@ module GemUpdater
     # @param file_name [String] file name of changelog
     # @return [Boolean] true if file may contain an anchor
     def changelog_may_contain_anchor?( file_name )
-      %w( .md .rdoc ).include?( File.extname( file_name ) )
+      %w( .md .rdoc .textile ).include?( File.extname( file_name ) )
     end
 
     # GitHubParser is responsible for parsing source code


### PR DESCRIPTION
Changelog in `textile` format should also be recognized as something
that may contain anchor.

Related #39

Details
* ADD support of `textile` files