### PR TITLE
ADD recognition of Changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master (unreleased)
+
+Enhancement:
+* add recognition of `Changes` as a changelog
+
 # 0.4.1 (August 11, 2015)
 
 Fix:

--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -70,7 +70,9 @@ module GemUpdater
     #
     # @return [Array] list of possible names
     def changelog_names
-      %w( CHANGELOG Changelog ChangeLog changelog HISTORY History history )
+      base_names = %w( changelog history changes )
+      other_names = %w( ChangeLog )
+      base_names + base_names.map( &:upcase ) + base_names.map( &:capitalize ) + other_names
     end
 
     # Some documents like the one written in markdown may contain


### PR DESCRIPTION
A changelog named `changes` was not recognized.

Related #38

Details
* ADD support for file named `changes`