### PR TITLE
Fix gem updater template link in the Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ By default, diff for your gems will look like the following:
 ```
 
 You can change it if you like by writing you own template `.gem_updater_template.erb` in your home directory.
-[Look at default template](https://github.com/MaximeD/gem_updater/lib/gem_updater_template.erb) for an example on how to do it.
+[Look at default template](lib/gem_updater_template.erb) for an example on how to do it.
 
 ## Contributing
 


### PR DESCRIPTION
The link to the gem updater template in the Readme is broken. Also, [GitHub](https://help.github.com/articles/relative-links-in-readmes/) suggests using relative links in Readme's as a best practice.