### PR TITLE
FIX rubygems returning blank values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master (unreleased)
+
+Fix:
+* considering `''` as a valid url to parse
+
 # 0.4.3 (October 15, 2015)
 
 Enhancement:

--- a/lib/gem_updater/ruby_gems_fetcher.rb
+++ b/lib/gem_updater/ruby_gems_fetcher.rb
@@ -38,7 +38,11 @@ module GemUpdater
       end
 
       if response
-        response[ "source_code_uri" ] || response[ "homepage_uri" ]
+        response[
+          %w( source_code_uri homepage_uri ).find do |key|
+            response[ key ] && !response[ key ].empty?
+          end
+        ]
       end
     end
 

--- a/spec/gem_updater/ruby_gems_fetcher_spec.rb
+++ b/spec/gem_updater/ruby_gems_fetcher_spec.rb
@@ -38,9 +38,21 @@ describe GemUpdater::RubyGemsFetcher do
         end
       end
 
-      context 'none is present' do
+      context 'when none is present' do
         before do
           allow( subject ).to receive_message_chain( :open, :read ) { {}.to_json }
+          allow( subject ).to receive( :uri_from_other_sources )
+          subject.source_uri
+        end
+
+        it 'looks in other sources' do
+          expect( subject ).to have_received( :uri_from_other_sources )
+        end
+      end
+
+      context 'when both returns empty string' do
+        before do
+          allow( subject ).to receive_message_chain( :open, :read ) { { source_code_uri: '', homepage_uri: '' }.to_json }
           allow( subject ).to receive( :uri_from_other_sources )
           subject.source_uri
         end


### PR DESCRIPTION
We look for an url to parse in response from rubygems.
Ideally, if there is no url, response should not even define it,
but for some gems it will return an empty string,
leading to `open-uri` crashing when attempting to open a blank url.

We should not only check if something is returned, but also that it is
not an empty string.

Related #43

Details
* FIX considering `''` as an url
* UPDATE specs