### PR TITLE
FIX making too many requests

### DIFF
--- a/spec/gem_updater/ruby_gems_fetcher_spec.rb
+++ b/spec/gem_updater/ruby_gems_fetcher_spec.rb
@@ -5,6 +5,18 @@ describe GemUpdater::RubyGemsFetcher do
 
   describe '#source_uri' do
     context 'when gem exists on rubygems.org' do
+
+      describe 'making too many requests' do
+        before do
+          allow( subject ).to receive_message_chain( :open ) { raise OpenURI::HTTPError.new( '429', OpenStruct.new( status: [ '429' ] ) ) }
+          subject.source_uri
+        end
+
+        it 'tries again' do
+          expect( subject ).to have_received( :open ).twice
+        end
+      end
+
       context "when 'source_code_uri' is present" do
         before do
           allow( subject ).to receive_message_chain( :open, :read ) { { source_code_uri: 'source_code_uri' }.to_json }


### PR DESCRIPTION
We may be trigerring too many requests to rubygems.
In which case it won't send us the information we need.
If such a thing happens, we should wait a while before making a new
request.

Details
* FIX making too many requests
* ADD specs