### PR TITLE
FIX using other source with rubygems

### DIFF
--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -19,10 +19,12 @@ module GemUpdater
     # @return [String, nil] URL of changelog
     def changelog
       @changelog ||= begin
-        Bundler.ui.warn "Looking for a changelog in #{@uri}"
-        doc = Nokogiri::HTML( open( @uri ) )
+        if @uri
+          Bundler.ui.warn "Looking for a changelog in #{@uri}"
+          doc = Nokogiri::HTML( open( @uri ) )
 
-        find_changelog( doc )
+          find_changelog( doc )
+        end
 
       rescue OpenURI::HTTPError # Uri points to nothing
         Bundler.ui.error "Cannot find #{@uri}"
@@ -41,18 +43,20 @@ module GemUpdater
     # @param url [String] the url to parse
     # @return [URI] valid URI
     def correct_uri( url )
-      uri = URI( url )
-      if uri.scheme == 'http'
-        case
-        when uri.host.match( 'github.com' )
-          # remove possible subdomain like 'wiki.github.com'
-          uri = URI "https://github.com#{uri.path}"
-        when uri.host.match( 'bitbucket.org' )
-          uri = URI "https://#{uri.host}#{uri.path}"
+      if String === url and ! url.empty?
+        uri = URI( url )
+        if uri.scheme == 'http'
+          case
+          when uri.host.match( 'github.com' )
+            # remove possible subdomain like 'wiki.github.com'
+            uri = URI "https://github.com#{uri.path}"
+          when uri.host.match( 'bitbucket.org' )
+            uri = URI "https://#{uri.host}#{uri.path}"
+          end
         end
-      end
 
-      uri
+        uri
+      end
     end
 
     # Try to find where changelog might be.


### PR DESCRIPTION
When using an other source (a geminabox install in my case) along with
rubygems, gem_updater will crash when trying to find the changelog

```
uri/common.rb:715:in `URI': bad argument (expected URI object or URI string) (ArgumentError)
        from gem_updater-0.4.5/lib/gem_updater/source_page_parser.rb:44:in `correct_uri'
        from gem_updater-0.4.5/lib/gem_updater/source_page_parser.rb:13:in `initialize'
        from gem_updater-0.4.5/lib/gem_updater.rb:51:in `new'
        from gem_updater-0.4.5/lib/gem_updater.rb:51:in `block (2 levels) in fill_changelogs'
```

With this patch, it will simply ignore an unusable url. Don't ask me
why, but the url passed to `SourcePageParser#correct_uri` for a
geminabox gem was an `IO` instead of being a `String`.