### PR TITLE
FIX redirections for rubygems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master (unreleased)
+
+Fix:
+* `https` redirection for `rubygems.org`
+
 # v0.5.0 (April 09, 2016)
 
 Fix:

--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -6,7 +6,11 @@ module GemUpdater
   # SourcePageParser is responsible for parsing a source page where
   # the gem code is hosted.
   class SourcePageParser
-    HOSTS = { github: /github.com/, bitbucket: /bitbucket.org/ }.freeze
+    HOSTS = {
+      github: /github.com/,
+      bitbucket: /bitbucket.org/,
+      rubygems: /rubygems.org/
+    }.freeze
     MARKUP_FILES = %w[.md .rdoc .textile].freeze
     CHANGELOG_NAMES = %w[changelog ChangeLog history changes news].freeze
 
@@ -71,6 +75,8 @@ module GemUpdater
         # remove possible subdomain like 'wiki.github.com'
         URI "https://github.com#{uri.path}"
       when uri.host =~ HOSTS[:bitbucket]
+        URI "https://#{uri.host}#{uri.path}"
+      when uri.host =~ HOSTS[:rubygems]
         URI "https://#{uri.host}#{uri.path}"
       else
         uri


### PR DESCRIPTION
Some gems consider their source page is `rubygems.org`. Obviously no
changelog will be find there, but the real problem is that it will fail
in case uri is in `http` instead of `https`.

Details
* ADD `https` redirection for `rubygems.org`