### PR TITLE
ADD code coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master (unreleased)
+
+Development tools:
+* add code coverage
+
 # v0.5.1 (May 24, 2016)
 
 Fix:

--- a/Gemfile
+++ b/Gemfile
@@ -3,5 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
+  gem 'codacy-coverage', require: false
   gem 'rake'
+  gem 'simplecov', require: false
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,12 +9,26 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    codacy-coverage (0.3.1)
+      rest-client (~> 1.8)
+      simplecov (>= 0.10.0)
     diff-lcs (1.2.5)
+    docile (1.1.5)
+    domain_name (0.5.20160310)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
     json (1.8.3)
+    mime-types (2.99.1)
     mini_portile2 (2.0.0)
+    netrc (0.11.0)
     nokogiri (1.6.7.2)
       mini_portile2 (~> 2.0.0.rc2)
     rake (11.1.2)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)
@@ -28,14 +42,24 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.4.0)
     rspec-support (3.4.1)
+    simplecov (0.11.2)
+      docile (~> 1.1.0)
+      json (~> 1.8)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.0)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  codacy-coverage
   gem_updater!
   rake
   rspec (~> 3.0)
+  simplecov
 
 BUNDLED WITH
    1.12.4

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,9 @@
+require 'codacy-coverage'
 require 'gem_updater'
+require 'simplecov'
+
+Codacy::Reporter.start
+SimpleCov.start
 
 Dir["#{File.expand_path('../support', __FILE__)}/*.rb"].each do |file|
   require file


### PR DESCRIPTION
We should have some insights on how much code is covered. In order to do
so, `simplecov` can be used and results parsed by `codacy`.

Details
* ADD gem `simplecov`
* ADD gem `codacy-coverage`
* UPDATE `spec_helper` to generate code coverage
* IGNORE coverage results in `.gitignore`