### PR TITLE
FIX github parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master (unreleased)
 
+Fix:
+* css selector for github
+
 Development tools:
 * add code coverage
 * add codacy badges

--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -151,7 +151,7 @@ module GemUpdater
       # @return [String, nil] url of changelog
       def find_changelog_link
         changelog_names.find do |name|
-          node = doc.at_css(%(table.files a[title^="#{name}"]))
+          node = doc.at_css(%(table.files .content a[title^="#{name}"]))
 
           break node.attr('href') if node
         end


### PR DESCRIPTION
When parsing a github repository, we may find an incorrect changelog
link in case the keyword changelog is used in description too. For
instance:
```
<td>Changelog.md</td> <td>changelog for #2278</td>
```
This will point to the commit message instead of the file.
To prevent this, selector should be more specific.

Details
* FIX css selector for parser