### PR TITLE
ADD bundler caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 before_install:
   - gem install bundler # use the latest bundler, since Travis doesn't update for us
 rvm:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Fix:
 * css selector for github
 
 Development tools:
+* add `bundler` caching on travis
 * add code coverage
 * add codacy badges
 


### PR DESCRIPTION
Travis is not caching bundler gems by default. Well we can tell it to do
so.

Details
* ENABLE `bundler` caching