### PR TITLE
UPDATE gems and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Fix:
 * css selector for github
 
+Updates:
+* gems and dependencies
+
 Development tools:
 * add `bundler` caching on travis
 * add code coverage

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,54 +2,42 @@ PATH
   remote: .
   specs:
     gem_updater (0.5.1)
-      bundler (~> 1.10)
-      json (~> 1.8)
+      bundler (~> 1.12)
+      json (~> 2.0)
       nokogiri (~> 1.6)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    codacy-coverage (0.3.1)
-      rest-client (~> 1.8)
+    codacy-coverage (1.0.0)
       simplecov (>= 0.10.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
-    domain_name (0.5.20160310)
-      unf (>= 0.0.5, < 1.0.0)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
-    json (1.8.3)
-    mime-types (2.99.1)
-    mini_portile2 (2.0.0)
-    netrc (0.11.0)
-    nokogiri (1.6.7.2)
-      mini_portile2 (~> 2.0.0.rc2)
-    rake (11.1.2)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.4)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    json (2.0.1)
+    mini_portile2 (2.1.0)
+    nokogiri (1.6.8)
+      mini_portile2 (~> 2.1.0)
+      pkg-config (~> 1.1.7)
+    pkg-config (1.1.7)
+    rake (11.2.2)
+    rspec (3.5.0)
+      rspec-core (~> 3.5.0)
+      rspec-expectations (~> 3.5.0)
+      rspec-mocks (~> 3.5.0)
+    rspec-core (3.5.1)
+      rspec-support (~> 3.5.0)
+    rspec-expectations (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
+      rspec-support (~> 3.5.0)
+    rspec-mocks (3.5.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
-    simplecov (0.11.2)
+      rspec-support (~> 3.5.0)
+    rspec-support (3.5.0)
+    simplecov (0.12.0)
       docile (~> 1.1.0)
-      json (~> 1.8)
+      json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
@@ -58,8 +46,8 @@ DEPENDENCIES
   codacy-coverage
   gem_updater!
   rake
-  rspec (~> 3.0)
+  rspec (~> 3.5)
   simplecov
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/gem_updater.gemspec
+++ b/gem_updater.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_runtime_dependency 'bundler',   '~> 1.10'
-  s.add_runtime_dependency 'json',      '~> 1.8'
+  s.add_runtime_dependency 'bundler',   '~> 1.12'
+  s.add_runtime_dependency 'json',      '~> 2.0'
   s.add_runtime_dependency 'nokogiri',  '~> 1.6'
 
-  s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'rspec', '~> 3.5'
 
   s.executables << 'gem_update'
 end


### PR DESCRIPTION
Details:

* codacy-coverage 0.3.1 → 1.0.0

* json 1.8.3 → 2.0.1
[changelog](https://github.com/flori/json/blob/master/CHANGES.md#2016-07-01-201)

* mini_portile2 2.0.0 → 2.1.0
[changelog](https://github.com/flavorjones/mini_portile/blob/master/CHANGELOG.md#210--2016-01-06)

* nokogiri 1.6.7.2 → 1.6.8
[changelog](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#168--2016-06-06)

* rake 11.1.2 → 11.2.2
[changelog](https://github.com/ruby/rake/blob/master/History.rdoc#1122--2016-06-12)

* rspec 3.4.0 → 3.5.0

* rspec-core 3.4.4 → 3.5.1
[changelog](https://github.com/rspec/rspec-core/blob/master/Changelog.md#351--2016-07-06)

* rspec-expectations 3.4.0 → 3.5.0
[changelog](https://github.com/rspec/rspec-expectations/blob/master/Changelog.md#350--2016-07-01)

* rspec-mocks 3.4.1 → 3.5.0
[changelog](https://github.com/rspec/rspec-mocks/blob/master/Changelog.md#350--2016-07-01)

* rspec-support 3.4.1 → 3.5.0
[changelog](https://github.com/rspec/rspec-support/blob/master/Changelog.md#350--2016-07-01)

* simplecov 0.11.2 → 0.12.0
[changelog](https://github.com/colszowka/simplecov/blob/master/CHANGELOG.md#0120-2016-07-02-changes)