### PR TITLE
FIX bundler locked gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# master (unreleased)
+
+Fix:
+* compatibility with bundler 1.13
+
+
 # v0.5.2 (July 11, 2016)
 
 Fix:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     gem_updater (0.5.2)
-      bundler (~> 1.12)
+      bundler (~> 1.13)
       json (~> 2.0)
       nokogiri (~> 1.6)
 
@@ -15,10 +15,8 @@ GEM
     docile (1.1.5)
     json (2.0.1)
     mini_portile2 (2.1.0)
-    nokogiri (1.6.8)
+    nokogiri (1.6.8.1)
       mini_portile2 (~> 2.1.0)
-      pkg-config (~> 1.1.7)
-    pkg-config (1.1.7)
     rake (11.2.2)
     rspec (3.5.0)
       rspec-core (~> 3.5.0)
@@ -50,4 +48,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.12.5
+   1.13.6

--- a/gem_updater.gemspec
+++ b/gem_updater.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.0.0'
 
-  s.add_runtime_dependency 'bundler',   '~> 1.12'
+  s.add_runtime_dependency 'bundler',   '~> 1.13'
   s.add_runtime_dependency 'json',      '~> 2.0'
   s.add_runtime_dependency 'nokogiri',  '~> 1.6'
 

--- a/lib/gem_updater/gem_file.rb
+++ b/lib/gem_updater/gem_file.rb
@@ -53,6 +53,7 @@ module GemUpdater
     # Use a hacky way to tell bundle we want to parse the new `Gemfile.lock`
     def reinitialize_spec_set!
       Bundler.remove_instance_variable('@locked_gems')
+      Bundler.remove_instance_variable('@definition')
     end
 
     # Add changes to between two versions of a gem


### PR DESCRIPTION
Since bundler `1.13`, `gem_updater` is not aware of any changelog.
This is because it fails getting new specs set from bundler.

Details
* FIX computing changes