### PR TITLE
FIX url accessible via OAuth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master (unreleased)
 
+Fix:
+* parsing urls with `x-oauth-token`
+
 Development tools:
 * ADD gemnasium badge
 

--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -27,19 +27,22 @@ module GemUpdater
     #
     # @return [String, nil] URL of changelog
     def changelog
-      @changelog ||= begin
-        if uri
-          Bundler.ui.warn "Looking for a changelog in #{uri}"
-          doc = Nokogiri::HTML(open(uri))
+      return unless uri
 
-          find_changelog(doc)
-        end
+      @changelog ||= begin
+        Bundler.ui.warn "Looking for a changelog in #{uri}"
+        doc = Nokogiri::HTML(open(uri))
+
+        find_changelog(doc)
 
       rescue OpenURI::HTTPError # Uri points to nothing
         Bundler.ui.error "Cannot find #{uri}"
         false
       rescue Errno::ETIMEDOUT # timeout
         Bundler.ui.error "#{uri} is down"
+        false
+      rescue ArgumentError => e # x-oauth-basic raises userinfo not supported. [RFC3986]
+        Bundler.ui.error e
         false
       end
     end

--- a/spec/gem_updater/source_page_parser_spec.rb
+++ b/spec/gem_updater/source_page_parser_spec.rb
@@ -2,13 +2,13 @@ require 'spec_helper'
 
 describe GemUpdater::SourcePageParser do
   describe '#changelog' do
-    subject do
-      GemUpdater::SourcePageParser.new(
-        url: 'https://github.com/fake_user/fake_gem', version: '0.2'
-      )
-    end
-
     context 'when gem is hosted on github' do
+      subject do
+        GemUpdater::SourcePageParser.new(
+          url: 'https://github.com/fake_user/fake_gem', version: '0.2'
+        )
+      end
+
       context 'when there is no changelog' do
         before do
           allow(subject).to receive(:open) { github_gem_without_changelog }
@@ -45,6 +45,19 @@ describe GemUpdater::SourcePageParser do
         it 'returns url of changelog with anchor to version' do
           expect(subject.changelog).to eq 'https://github.com/fake_user/fake_gem/blob/master/changelog.md#02'
         end
+      end
+    end
+
+    describe 'handling errors' do
+      context 'when url is not reachable' do
+        subject do
+          GemUpdater::SourcePageParser.new(
+            url: 'https://token:x-oauth-basic@github.com/fake_user/fake_gem',
+            version: '0.2'
+          ).changelog
+        end
+
+        it { is_expected.to be false }
       end
     end
   end


### PR DESCRIPTION
Some private gems can use something like
```
gem 'private_gem',
  git: 'https://<token>:x-oauth-basic@github.com/<organisation>/<project>'
```

This will raise a `userinfo not supported.  [RFC3986] (ArgumentError)`
that should be catched.

Details
* FIX urls with oauth token
* ADD specs