### PR TITLE
UPDATE gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master (unreleased)
+
+Updates:
+* gems and dependencies
+
 # v2.1.2 (July 02, 2017)
 
 Updates:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,40 +2,40 @@ PATH
   remote: .
   specs:
     gem_updater (2.1.2)
-      bundler (~> 1.15)
+      bundler (~> 1.16)
       json (~> 2.1)
       nokogiri (~> 1.8)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    codacy-coverage (1.1.6)
+    codacy-coverage (1.1.8)
       simplecov
     diff-lcs (1.3)
     docile (1.1.5)
     json (2.1.0)
-    mini_portile2 (2.2.0)
-    nokogiri (1.8.0)
-      mini_portile2 (~> 2.2.0)
-    rake (12.0.0)
-    rspec (3.6.0)
-      rspec-core (~> 3.6.0)
-      rspec-expectations (~> 3.6.0)
-      rspec-mocks (~> 3.6.0)
-    rspec-core (3.6.0)
-      rspec-support (~> 3.6.0)
-    rspec-expectations (3.6.0)
+    mini_portile2 (2.3.0)
+    nokogiri (1.8.1)
+      mini_portile2 (~> 2.3.0)
+    rake (12.3.0)
+    rspec (3.7.0)
+      rspec-core (~> 3.7.0)
+      rspec-expectations (~> 3.7.0)
+      rspec-mocks (~> 3.7.0)
+    rspec-core (3.7.0)
+      rspec-support (~> 3.7.0)
+    rspec-expectations (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-mocks (3.6.0)
+      rspec-support (~> 3.7.0)
+    rspec-mocks (3.7.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.6.0)
-    rspec-support (3.6.0)
-    simplecov (0.14.1)
+      rspec-support (~> 3.7.0)
+    rspec-support (3.7.0)
+    simplecov (0.15.1)
       docile (~> 1.1.0)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.1)
+    simplecov-html (0.10.2)
 
 PLATFORMS
   ruby
@@ -44,8 +44,8 @@ DEPENDENCIES
   codacy-coverage
   gem_updater!
   rake
-  rspec (~> 3.6)
+  rspec (~> 3.7)
   simplecov
 
 BUNDLED WITH
-   1.15.1
+   1.16.0

--- a/gem_updater.gemspec
+++ b/gem_updater.gemspec
@@ -12,11 +12,11 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.1.0'
 
-  s.add_runtime_dependency 'bundler',   '~> 1.15'
+  s.add_runtime_dependency 'bundler',   '~> 1.16'
   s.add_runtime_dependency 'json',      '~> 2.1'
   s.add_runtime_dependency 'nokogiri',  '~> 1.8'
 
-  s.add_development_dependency 'rspec', '~> 3.6'
+  s.add_development_dependency 'rspec', '~> 3.7'
 
   s.executables << 'gem_update'
 end


### PR DESCRIPTION
* bundler 1.15 → 1.16
[changelog](https://github.com/bundler/bundler/blob/1-16-stable/CHANGELOG.md)

* codacy-coverage 1.1.6 → 1.1.8

* mini_portile2 2.2.0 → 2.3.0
[changelog](https://github.com/flavorjones/mini_portile/blob/master/CHANGELOG.md)

* nokogiri 1.8.0 → 1.8.1
[changelog](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#181--2017-09-19)

* rake 12.0.0 → 12.3.0
[changelog](https://github.com/ruby/rake/blob/master/History.rdoc#1230)

* rspec 3.6.0 → 3.7.0

* rspec-core 3.6.0 → 3.7.0
[changelog](https://github.com/rspec/rspec-core/blob/master/Changelog.md#370--2017-10-17)

* rspec-expectations 3.6.0 → 3.7.0
[changelog](https://github.com/rspec/rspec-expectations/blob/master/Changelog.md#370--2017-10-17)

* rspec-mocks 3.6.0 → 3.7.0
[changelog](https://github.com/rspec/rspec-mocks/blob/master/Changelog.md#370--2017-10-17)

* rspec-support 3.6.0 → 3.7.0
[changelog](https://github.com/rspec/rspec-support/blob/master/Changelog.md#370--2017-05-04)

* simplecov 0.14.1 → 0.15.1
[changelog](https://github.com/colszowka/simplecov/blob/master/CHANGELOG.md#0151-2017-09-11-changes)

* simplecov-html 0.10.1 → 0.10.2
[changelog](https://github.com/colszowka/simplecov-html/blob/master/CHANGELOG.md#0102-2017-08-14)