### PR TITLE
ADD CI for ruby 2.5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ cache: bundler
 before_install:
   - gem install bundler # use the latest bundler, since Travis doesn't update for us
 rvm:
+  - 2.5.0
   - 2.4.0
   - 2.3.0
   - 2.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# master (unreleased)
+
+Development tools:
+* add CI support for ruby 2.5.0
+
 # v2.1.3 (November 19, 2017)
 
 Updates:


### PR DESCRIPTION
Since ruby `2.5.0` is out, CI should ensure build also passes on this
version.

Details
* ADD CI support for ruby `2.5.0`