### PR TITLE
FIX codeclimate badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![Version     ](https://img.shields.io/gem/v/gem_updater.svg?style=flat)](https://rubygems.org/gems/gem_updater)
 [![Build Status](https://img.shields.io/travis/MaximeD/gem_updater/master.svg?style=flat)](https://travis-ci.org/MaximeD/gem_updater)
-[![Code Climate](https://img.shields.io/codeclimate/github/MaximeD/gem_updater.svg?style=flat)](https://codeclimate.com/github/MaximeD/gem_updater)
+[![Maintainability](https://api.codeclimate.com/v1/badges/74dc27b2f9635ecb851a/maintainability)](https://codeclimate.com/github/MaximeD/gem_updater/maintainability)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d6d4f756ade048bd86624347856da9ea)](https://www.codacy.com/app/MaximeD/gem_updater?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=MaximeD/gem_updater&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/d6d4f756ade048bd86624347856da9ea)](https://www.codacy.com/app/MaximeD/gem_updater?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=MaximeD/gem_updater&amp;utm_campaign=Badge_Coverage)
 [![Dependency Status](https://gemnasium.com/badges/github.com/MaximeD/gem_updater.svg)](https://gemnasium.com/github.com/MaximeD/gem_updater)


### PR DESCRIPTION
Code climate badges are not accessible through `img.shields.io` anymore.

Details
* FIX image link for codeclimate