### PR TITLE
UPDATE gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+Updates:
+* gems and dependencies
+
 # v3.0.0 (March 10, 2018)
 
 Deprecations:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,12 +12,12 @@ GEM
     codacy-coverage (1.1.8)
       simplecov
     diff-lcs (1.3)
-    docile (1.1.5)
+    docile (1.3.1)
     json (2.1.0)
     mini_portile2 (2.3.0)
-    nokogiri (1.8.2)
+    nokogiri (1.8.4)
       mini_portile2 (~> 2.3.0)
-    rake (12.3.0)
+    rake (12.3.1)
     rspec (3.7.0)
       rspec-core (~> 3.7.0)
       rspec-expectations (~> 3.7.0)
@@ -31,8 +31,8 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.7.0)
     rspec-support (3.7.1)
-    simplecov (0.15.1)
-      docile (~> 1.1.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
@@ -48,4 +48,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.16.1
+   1.16.3


### PR DESCRIPTION
* docile 1.1.5 → 1.3.1
[changelog](https://github.com/ms-ati/docile/blob/master/HISTORY.md#v131-may-24-2018)

* nokogiri 1.8.2 → 1.8.4
[changelog](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#184--2018-07-03)

* rake 12.3.0 → 12.3.1
[changelog](https://github.com/ruby/rake/blob/master/History.rdoc#1231)

* simplecov 0.15.1 → 0.16.1
[changelog](https://github.com/colszowka/simplecov/blob/master/CHANGELOG.md#0161-2018-03-16)