### PR TITLE
REMOVE gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Maintainability](https://api.codeclimate.com/v1/badges/74dc27b2f9635ecb851a/maintainability)](https://codeclimate.com/github/MaximeD/gem_updater/maintainability)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/d6d4f756ade048bd86624347856da9ea)](https://www.codacy.com/app/MaximeD/gem_updater?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=MaximeD/gem_updater&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/d6d4f756ade048bd86624347856da9ea)](https://www.codacy.com/app/MaximeD/gem_updater?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=MaximeD/gem_updater&amp;utm_campaign=Badge_Coverage)
-[![Dependency Status](https://gemnasium.com/badges/github.com/MaximeD/gem_updater.svg)](https://gemnasium.com/github.com/MaximeD/gem_updater)
 [![Inline docs ](http://inch-ci.org/github/MaximeD/gem_updater.svg?style=flat)](http://inch-ci.org/github/MaximeD/gem_updater)
 
 


### PR DESCRIPTION
Since gemnasium has been closed (because it got acquired by gitlab), its
badge won't work anymore.

Details
* REMOVE gemnasium badge in `README.md`