### PR TITLE
UPDATE gems

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,28 +9,28 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    codacy-coverage (1.1.8)
+    codacy-coverage (2.1.0)
       simplecov
     diff-lcs (1.3)
     docile (1.3.1)
     json (2.1.0)
-    mini_portile2 (2.3.0)
-    nokogiri (1.8.4)
-      mini_portile2 (~> 2.3.0)
-    rake (12.3.1)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    mini_portile2 (2.4.0)
+    nokogiri (1.10.1)
+      mini_portile2 (~> 2.4.0)
+    rake (12.3.2)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-support (3.7.1)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
     simplecov (0.16.1)
       docile (~> 1.1)
       json (>= 1.8, < 3)
@@ -48,4 +48,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.16.3
+   1.17.2


### PR DESCRIPTION
* codacy-coverage 1.1.8 → 2.1.0

* mini_portile2 2.3.0 → 2.4.0
[changelog](https://github.com/flavorjones/mini_portile/blob/master/CHANGELOG.md#240--2018-12-02)

* nokogiri 1.8.4 → 1.10.1
[changelog](https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#1101--2019-01-13)

* rake 12.3.1 → 12.3.2
[changelog](https://github.com/ruby/rake/blob/master/History.rdoc#1232)

* rspec 3.7.0 → 3.8.0

* rspec-core 3.7.1 → 3.8.0
[changelog](https://github.com/rspec/rspec-core/blob/master/Changelog.md#380--2018-08-04)

* rspec-expectations 3.7.0 → 3.8.2
[changelog](https://github.com/rspec/rspec-expectations/blob/master/Changelog.md#382--2018-10-09)

* rspec-mocks 3.7.0 → 3.8.0
[changelog](https://github.com/rspec/rspec-mocks/blob/master/Changelog.md#380--2018-08-04)

* rspec-support 3.7.1 → 3.8.0
[changelog](https://github.com/rspec/rspec-support/blob/master/Changelog.md#380--2018-08-04)