### PR TITLE
REFACTOR stubbing sleep in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Updates:
 
 Development tools:
 * add CI support for ruby 2.6.0
+* add sleep stub in specs
 
 # v3.0.0 (March 10, 2018)
 

--- a/spec/gem_updater/ruby_gems_fetcher_spec.rb
+++ b/spec/gem_updater/ruby_gems_fetcher_spec.rb
@@ -16,6 +16,7 @@ describe GemUpdater::RubyGemsFetcher do
     context 'when gem exists on rubygems.org' do
       describe 'making too many requests' do
         before do
+          allow_any_instance_of(described_class).to receive(:sleep).and_return(true)
           allow(subject).to receive_message_chain(:open) do
             raise OpenURI::HTTPError.new('429', OpenStruct.new(status: ['429']))
           end


### PR DESCRIPTION
The `sleep` is not stubbed in tests, making an unnecessary wait in
tests.