### PR TITLE
Unlock `bundler` dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 before_install:
+  - gem update --system
   - gem install bundler # use the latest bundler, since Travis doesn't update for us
 rvm:
   - 2.6.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     gem_updater (3.0.0)
-      bundler (~> 1.16)
+      bundler (< 3)
       json (~> 2.1)
       memoist (~> 0.16.0)
       nokogiri (~> 1.8)
@@ -66,4 +66,4 @@ DEPENDENCIES
   simplecov
 
 BUNDLED WITH
-   1.17.2
+   2.0.2

--- a/gem_updater.gemspec
+++ b/gem_updater.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.5.0'
 
-  s.add_runtime_dependency 'bundler',  '~> 1.16'
+  s.add_runtime_dependency 'bundler',  '< 3'
   s.add_runtime_dependency 'json',     '~> 2.1'
   s.add_runtime_dependency 'memoist',  '~> 0.16.0'
   s.add_runtime_dependency 'nokogiri', '~> 1.8'


### PR DESCRIPTION
When migrating to Bundler 2, there is no possibility to install the gem anymore.
We should update the dependency lock to allow Bundler 2.

Details:
- Bump `bundler` dependency to allow version 2