### PR TITLE
FIX ruby 2.7 compatibility

### DIFF
--- a/lib/gem_updater/gem_file.rb
+++ b/lib/gem_updater/gem_file.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bundler'
 require 'bundler/cli'
 
 module GemUpdater


### PR DESCRIPTION
Bundler needs to be required along with its cli, otherwise the following
raises:
```
bundler/cli.rb:111:in `<class:CLI>':
undefined method `feature_flag' for Bundler:Module (NoMethodError)
```