### PR TITLE
FIX shebang

### DIFF
--- a/bin/gem_update
+++ b/bin/gem_update
@@ -1,6 +1,7 @@
+#!/usr/bin/env ruby
+
 # frozen_string_literal: true
 
-#!/usr/bin/env ruby
 require 'optparse'
 
 # Exit cleanly from an early interrupt


### PR DESCRIPTION
As rubocop added the `frozen_string_literal` on top of the executable,
the shebang was not read anymore. That was just an issue on local
development, but still an issue.