### PR TITLE
FIX codacy coverage

### DIFF
--- a/.github/workflows/codacy-coverage-reporter.yml
+++ b/.github/workflows/codacy-coverage-reporter.yml
@@ -1,0 +1,18 @@
+name: codacy-coverage-reporter
+
+on:
+  workflow_run:
+    workflows: ["Ruby"]
+    types: [completed]
+
+jobs:
+  codacy-coverage-reporter:
+    runs-on: ubuntu-latest
+    name: codacy-coverage-reporter
+    steps:
+      - uses: actions/checkout@master
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage/coverage.xml

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :test do
-  gem 'codacy-coverage', require: false
   gem 'rake'
   gem 'simplecov', require: false
+  gem 'simplecov-cobertura'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,8 +13,6 @@ GEM
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.2)
-    codacy-coverage (2.2.1)
-      simplecov
     coderay (1.1.3)
     crack (0.4.5)
       rexml
@@ -71,6 +69,8 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (1.4.2)
+      simplecov (~> 0.8)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.2)
     unicode-display_width (2.0.0)
@@ -84,7 +84,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  codacy-coverage
   gem_updater!
   pry (~> 0.14)
   rake
@@ -92,8 +91,9 @@ DEPENDENCIES
   rubocop (~> 1.0)
   rubocop-performance (~> 1.5.2)
   simplecov
+  simplecov-cobertura
   vcr (~> 6.0)
   webmock (~> 3.8)
 
 BUNDLED WITH
-   2.2.9
+   2.2.22

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-[![Version     ](https://img.shields.io/gem/v/gem_updater.svg?style=flat)](https://rubygems.org/gems/gem_updater)
+[![Version](https://img.shields.io/gem/v/gem_updater.svg?style=flat)](https://rubygems.org/gems/gem_updater)
 [![Build Status](https://img.shields.io/travis/MaximeD/gem_updater/master.svg?style=flat)](https://travis-ci.com/MaximeD/gem_updater)
 [![Maintainability](https://api.codeclimate.com/v1/badges/74dc27b2f9635ecb851a/maintainability)](https://codeclimate.com/github/MaximeD/gem_updater/maintainability)
-[![Codacy Badge](https://api.codacy.com/project/badge/Grade/d6d4f756ade048bd86624347856da9ea)](https://www.codacy.com/app/MaximeD/gem_updater?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=MaximeD/gem_updater&amp;utm_campaign=Badge_Grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/6c95225b2b7249b7a723e847094a2c21)](https://www.codacy.com/gh/MaximeD/gem_updater/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=MaximeD/gem_updater&amp;utm_campaign=Badge_Grade)
 [![Codacy Badge](https://api.codacy.com/project/badge/Coverage/d6d4f756ade048bd86624347856da9ea)](https://www.codacy.com/app/MaximeD/gem_updater?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=MaximeD/gem_updater&amp;utm_campaign=Badge_Coverage)
 [![Inline docs ](http://inch-ci.org/github/MaximeD/gem_updater.svg?style=flat)](http://inch-ci.org/github/MaximeD/gem_updater)
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,11 @@
 # frozen_string_literal: true
 
-require 'codacy-coverage'
 require 'gem_updater'
 require 'simplecov'
+require 'simplecov-cobertura'
 
-Codacy::Reporter.start
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+
 SimpleCov.start
 
 Dir["#{File.expand_path('support', __dir__)}/*.rb"].sort.each { |file| require file }


### PR DESCRIPTION
Gem `codacy-coverage` has been deprecated and replaced by a reporter
available through a github action.