### PR TITLE
UPDATE gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 Enhancement:
 * add support for ruby 3.1
 
+Updates:
+* gems
+
 # v4.4.2 (July 14, 2021)
 
 Updates:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,10 +16,10 @@ GEM
     coderay (1.1.3)
     crack (0.4.5)
       rexml
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     docile (1.4.0)
     hashdiff (1.0.1)
-    json (2.5.1)
+    json (2.6.1)
     memoist (0.16.2)
     method_source (1.0.0)
     mini_portile2 (2.6.1)
@@ -33,7 +33,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.6)
-    racc (1.5.2)
+    racc (1.6.0)
     rainbow (3.0.0)
     rake (13.0.6)
     regexp_parser (2.2.0)
@@ -50,7 +50,7 @@ GEM
     rspec-mocks (3.10.2)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+    rspec-support (3.10.3)
     rubocop (1.24.1)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
@@ -62,21 +62,23 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.15.1)
       parser (>= 3.0.1.1)
-    rubocop-performance (1.5.2)
-      rubocop (>= 0.71.0)
+    rubocop-performance (1.13.1)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.11.0)
     simplecov (0.21.2)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
-    simplecov-cobertura (1.4.2)
-      simplecov (~> 0.8)
+    simplecov-cobertura (2.1.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.3)
     unicode-display_width (2.1.0)
     vcr (6.0.0)
-    webmock (3.13.0)
-      addressable (>= 2.3.6)
+    webmock (3.14.0)
+      addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
 
@@ -89,11 +91,11 @@ DEPENDENCIES
   rake
   rspec (~> 3.7)
   rubocop (~> 1.0)
-  rubocop-performance (~> 1.5.2)
+  rubocop-performance (~> 1.13)
   simplecov
   simplecov-cobertura
   vcr (~> 6.0)
   webmock (~> 3.8)
 
 BUNDLED WITH
-   2.2.22
+   2.3.3

--- a/gem_updater.gemspec
+++ b/gem_updater.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'pry', '~> 0.14'
   s.add_development_dependency 'rspec',   '~> 3.7'
   s.add_development_dependency 'rubocop', '~> 1.0'
-  s.add_development_dependency 'rubocop-performance', '~> 1.5.2'
+  s.add_development_dependency 'rubocop-performance', '~> 1.13'
   s.add_development_dependency 'vcr', '~> 6.0'
   s.add_development_dependency 'webmock', '~> 3.8'
 

--- a/lib/gem_updater/gem_file.rb
+++ b/lib/gem_updater/gem_file.rb
@@ -53,8 +53,8 @@ module GemUpdater
     # will return the same result.
     # Use a hacky way to tell bundle we want to parse the new `Gemfile.lock`
     def reinitialize_spec_set!
-      Bundler.remove_instance_variable('@locked_gems')
-      Bundler.remove_instance_variable('@definition')
+      Bundler.remove_instance_variable(:@locked_gems)
+      Bundler.remove_instance_variable(:@definition)
     end
 
     # Add changes to between two versions of a gem

--- a/spec/gem_updater/gem_file_spec.rb
+++ b/spec/gem_updater/gem_file_spec.rb
@@ -96,7 +96,7 @@ describe GemUpdater::GemFile do
     it 'reinitializes locked gems' do
       expect(Bundler).to have_received(
         :remove_instance_variable
-      ).with('@locked_gems')
+      ).with(:@locked_gems)
     end
   end
 end


### PR DESCRIPTION
UPDATE gems 

* diff-lcs 1.4.4 → 1.5.0
[changelog](https://github.com/halostatue/diff-lcs/blob/main/History.md#150--2021-12-23)

* json 2.5.1 → 2.6.1
[changelog](https://github.com/flori/json/blob/master/CHANGES.md#2021-10-24-261)

* racc 1.5.2 → 1.6.0
[changelog](https://github.com/ruby/racc/blob/master/ChangeLog)

* rspec-support 3.10.2 → 3.10.3
[changelog](https://github.com/rspec/rspec-support/blob/main/Changelog.md#3103--2021-11-03)

* rubocop-performance 1.5.2 → 1.13.1
[changelog](https://github.com/rubocop/rubocop-performance/blob/master/CHANGELOG.md#1131-2022-01-01)

* simplecov-cobertura 1.4.2 → 2.1.0

* webmock 3.13.0 → 3.14.0
[changelog](https://github.com/bblimke/webmock/blob/v3.14.0/CHANGELOG.md#3140)