### PR TITLE
Add diffend support

### DIFF
--- a/lib/gem_updater_template.erb
+++ b/lib/gem_updater_template.erb
@@ -1,4 +1,5 @@
 * <%= gem %> <%= details[:versions][:old] %> → <%= details[:versions][:new] %>
+[<%= gem %> diffend](https://my.diffend.io/gems/<%= gem %>/<%= details[:versions][:old] %>/<%= details[:versions][:new] %>)
 <% if details[:changelog] %>
 [changelog](<%= details[:changelog] %>)
 <% end %>

--- a/spec/gem_updater_spec.rb
+++ b/spec/gem_updater_spec.rb
@@ -69,9 +69,11 @@ describe GemUpdater::Updater do
     it 'outputs changes' do
       expect(Bundler.ui).to have_received(:info).with(<<~CHANGELOG)
         * fake_gem1 1.0 → 1.1
+        [fake_gem1 diffend](https://my.diffend.io/gems/fake_gem1/1.0/1.1)
         [changelog](fake_gem_1_url)
 
         * fake_gem2 0.4 → 0.4.2
+        [fake_gem2 diffend](https://my.diffend.io/gems/fake_gem2/0.4/0.4.2)
         [changelog](fake_gem_2_url)
 
       CHANGELOG
@@ -83,8 +85,8 @@ describe GemUpdater::Updater do
 
     it 'contains changes' do
       [
-        "* fake_gem1 1.0 → 1.1\n[changelog](fake_gem_1_url)\n\n",
-        "* fake_gem2 0.4 → 0.4.2\n[changelog](fake_gem_2_url)\n\n"
+        "* fake_gem1 1.0 → 1.1\n[fake_gem1 diffend](https://my.diffend.io/gems/fake_gem1/1.0/1.1)\n[changelog](fake_gem_1_url)\n\n",
+        "* fake_gem2 0.4 → 0.4.2\n[fake_gem2 diffend](https://my.diffend.io/gems/fake_gem2/0.4/0.4.2)\n[changelog](fake_gem_2_url)\n\n"
       ].each do |message|
         expect(subject.format_diff).to include message
       end


### PR DESCRIPTION
I'd like to suggest adding diffend links. It's a free service that automates diff'ing 2 gem versions. Looking at the CHANGELOG is nice, but the diff from the gems is also useful sometimes.

Example output:

![image](https://user-images.githubusercontent.com/191564/151998889-d84546d2-ae0c-4ee0-b1ce-3c6f7212f01f.png)

Example URL:

https://my.diffend.io/gems/puma/5.5.2/5.6.1