### PR TITLE
REMOVE support for old rubies

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.7', '3.0', '3.1']
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-performance
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 2.5
+  TargetRubyVersion: 2.7
 
 Layout/LineLength:
   Max: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master (unreleased)
 
+Deprecated:
+- support for ruby `2.5` and `2.6`
+
 # v4.5.0 (January 2, 2022)
 
 Enhancement:

--- a/gem_updater.gemspec
+++ b/gem_updater.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/MaximeD/gem_updater'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 2.5.0'
+  s.required_ruby_version = '>= 2.7.0'
 
   s.add_runtime_dependency 'bundler',  '< 3'
   s.add_runtime_dependency 'json',     '~> 2.1'

--- a/lib/gem_updater.rb
+++ b/lib/gem_updater.rb
@@ -40,11 +40,7 @@ module GemUpdater
     # Format the diff to get human readable information
     # on the gems that were updated.
     def format_diff
-      erb = if RUBY_VERSION.to_f < 3.0
-              ERB.new(template, nil, '<>')
-            else
-              ERB.new(template, trim_mode: '<>')
-            end
+      erb = ERB.new(template, trim_mode: '<>')
 
       gemfile.changes.map do |gem, details|
         erb.result(binding)

--- a/lib/gem_updater/source_page_parser.rb
+++ b/lib/gem_updater/source_page_parser.rb
@@ -150,9 +150,9 @@ module GemUpdater
       #
       # @return [String, nil] url of changelog
       def find_changelog_link
-        changelog_names.map do |name|
+        changelog_names.filter_map do |name|
           doc.at_css(%([aria-labelledby="files"] a[title^="#{name}"]))
-        end.compact.last&.attr('href')
+        end.last&.attr('href')
       end
 
       # Looks into document to find it there is an anchor to new gem version.
@@ -161,11 +161,9 @@ module GemUpdater
       # @return [String, nil] anchor's href
       def find_anchor(url)
         changelog_page = Nokogiri::HTML(URI.parse(url).open)
-        anchor = changelog_page.css(%(a.anchor)).find do |element|
+        changelog_page.css(%(a.anchor)).find do |element|
           element.attr('href').match(version.delete('.'))
-        end
-
-        anchor&.attr('href')
+        end&.attr('href')
       end
     end
   end


### PR DESCRIPTION
Ruby `2.6` will reach End Of Life by the end of the month. So no need to
keep maintaining it. And ruby `2.5` is already not supported anymore.