### PR TITLE
ADD version file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master (unreleased)
 
+Development tools:
+* add `version` file
+
 Updates:
 * gems
 

--- a/gem_updater.gemspec
+++ b/gem_updater.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative 'lib/gem_updater/version'
+
 Gem::Specification.new do |s|
   s.name        = 'gem_updater'
-  s.version     = '4.5.0'
+  s.version     = GemUpdater::VERSION
   s.summary     = 'Update your gems and find their changelogs'
   s.description = 'Updates the gems of your Gemfile ' \
                   'and fetches the links pointing to where their changelogs are'

--- a/lib/gem_updater/version.rb
+++ b/lib/gem_updater/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module GemUpdater
+  VERSION = '4.5.0'
+end

--- a/spec/gem_updater/version_spec.rb
+++ b/spec/gem_updater/version_spec.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe GemUpdater::VERSION do
+  subject(:version) { GemUpdater::VERSION }
+
+  it { is_expected.to match(/\A\d+\.\d+\.\d+(\.\w+)?\z/) }
+end


### PR DESCRIPTION
Version of the gem should be programmatically accessible, hence a
constant to define it rather than only having it in the gemspec.