### PR TITLE
REMOVE support for ruby 2.7

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.7', '3.0', '3.1', '3.2']
+        ruby: ['3.0', '3.1', '3.2']
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby ${{ matrix.ruby }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master (unreleased)
 
+Deprecated:
+* support for ruby `2.7`
+
 # v5.1.0 (December 26, 2022)
 
 Enhancement:
@@ -52,10 +55,6 @@ Updates:
 
 Fix:
 * changelogs not found on github since they revamped their UI
-
-Enhancement:
-* add support for ruby 2.7.0
-* add rubocop performance
 
 Updates:
 * `bundler` to version 2 (@anthony-robin)


### PR DESCRIPTION
Ruby 2.7 reached end of life and is no longer maintained.