### PR TITLE
UPDATE gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master (unreleased)
 
+Updates:
+* gems
+
 # v6.0.0 (April 5, 2023)
 
 Deprecated:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.3)
+    addressable (2.8.4)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     coderay (1.1.3)
@@ -23,7 +23,7 @@ GEM
     memoist (0.16.2)
     method_source (1.0.0)
     mini_portile2 (2.8.1)
-    nokogiri (1.14.2)
+    nokogiri (1.14.3)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     parallel (1.22.1)
@@ -51,7 +51,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
-    rubocop (1.49.0)
+    rubocop (1.50.1)
       json (~> 2.3)
       parallel (~> 1.10)
       parser (>= 3.2.0.0)
@@ -63,7 +63,7 @@ GEM
       unicode-display_width (>= 2.4.0, < 3.0)
     rubocop-ast (1.28.0)
       parser (>= 3.2.1.0)
-    rubocop-performance (1.16.0)
+    rubocop-performance (1.17.1)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     ruby-progressbar (1.13.0)
@@ -99,4 +99,4 @@ DEPENDENCIES
   webmock (~> 3.18)
 
 BUNDLED WITH
-   2.4.10
+   2.4.12


### PR DESCRIPTION
* addressable 2.8.3  → 2.8.4 [changelog](https://github.com/sporkmonger/addressable/blob/main/CHANGELOG.md#addressable-284)

* nokogiri 1.14.2 → 1.14.3 [changelog](https://github.com/sparklemotion/nokogiri/blob/main/CHANGELOG.md#1143--2023-04-11)

* rubocop 1.49.0 → 1.50.1 [changelog](https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md)

* rubocop-performance 1.16.0 → 1.17.1 [changelog](https://github.com/rubocop/rubocop-performance/blob/master/CHANGELOG.md#1171-2023-04-09)