### PR TITLE
FIX github worklow for gem-push

### DIFF
--- a/.github/workflows/gem-push.yml
+++ b/.github/workflows/gem-push.yml
@@ -14,11 +14,11 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby 3.3
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.3.3
+        ruby-version: 3.3
 
     - name: Publish to RubyGems
       run: |


### PR DESCRIPTION
The workflow is failing with error

```
Unknown version 3.3.3 for ruby on ubuntu-22.04
```

This patch relaxes the ruby version to omit the patch, so that ubuntu will use the latest available one.