### PR TITLE
DROP ruby 3.0 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.0', '3.1', '3.2', '3.3']
+        ruby: ['3.1', '3.2', '3.3']
     steps:
     - uses: actions/checkout@v4
     - name: Set up Ruby ${{ matrix.ruby }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ require: rubocop-performance
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.0
+  TargetRubyVersion: 3.1
 
 Gemspec/DevelopmentDependencies:
   Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master (unreleased)
 
+Deprecated:
+* ruby 3.1 is the minimum required ruby version
+
 Updates:
 * gems
 

--- a/gem_updater.gemspec
+++ b/gem_updater.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.required_ruby_version = '>= 3.0.0'
+  s.required_ruby_version = '>= 3.1'
 
   s.add_dependency 'bundler',  '< 3'
   s.add_dependency 'json',     '~> 2.6'


### PR DESCRIPTION
Ruby 3.0 reach End Of Life on 2024-04-23.