### PR TITLE
UPDATE gems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # master (unreleased)
 
+Updates:
+* gems
+
 # v7.4.0 (December 26, 2024)
 
 Enhancement:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,7 +25,7 @@ GEM
     language_server-protocol (3.17.0.3)
     method_source (1.1.0)
     mini_portile2 (2.8.8)
-    nokogiri (1.18.0)
+    nokogiri (1.18.1)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
     parallel (1.26.3)


### PR DESCRIPTION
* nokogiri 1.18.0 → 1.18.1 [changelog](https://nokogiri.org/CHANGELOG.html)