### PR TITLE
UPDATE syntax for rubocop plugins

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,5 @@
-require: rubocop-performance
+plugins:
+  - rubocop-performance
 
 AllCops:
   NewCops: enable


### PR DESCRIPTION
The syntax to load plugins changed.

See: https://docs.rubocop.org/rubocop/extensions.html#loading-extensions