### PR TITLE
REFACTOR GitHub actions

### DIFF
--- a/.github/workflows/ruby-gem.yml
+++ b/.github/workflows/ruby-gem.yml
@@ -1,4 +1,4 @@
-name: Ruby Gem
+name: 📦 Ruby Gem
 
 on:
   push:

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,6 +4,7 @@ on: push
 
 jobs:
   test:
+    name: 🧪 Test (ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -19,11 +20,22 @@ jobs:
       # Exclude acceptance specs as github action fails due to:
       # It is a security vulnerability to allow your home directory to be world-writable, and bundler cannot continue.
       run: bundle exec rspec --exclude-pattern "spec/acceptance/**/*_spec.rb"
-    - name: Run linter
-      run: make lint
 
     - name: Report coverage
       uses: codacy/codacy-coverage-reporter-action@v1
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: coverage/coverage.xml
+
+  lint:
+    name: 🧹 Lint
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Ruby 3.4
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.4
+        bundler-cache: true # 'bundle install' and cache gems
+    - name: Lint
+      run: make lint


### PR DESCRIPTION
This patch is refactoring the GitHub actions to:

1. extract `lint` to a dedicated job, since we don’t need to run it for every ruby version
2. add some emojis for visibility