### PR TITLE
FIX workflow permissions

### DIFF
--- a/.github/workflows/ruby-gem.yml
+++ b/.github/workflows/ruby-gem.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - '*'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build + Publish

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -2,6 +2,9 @@ name: 💎 Ruby
 
 on: push
 
+permissions:
+  contents: read
+  
 jobs:
   test:
     name: 🧪 Test (ruby ${{ matrix.ruby }})


### PR DESCRIPTION
This patch limits the permissions of the `GITHUB_TOKEN` used in the workflows.