### PR TITLE
DROP ruby 3.2 support

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.3", "3.4", "4.0"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Ruby ${{ matrix.ruby }}

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ plugins:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
 
 Gemspec/DevelopmentDependencies:
   Enabled: false
@@ -12,5 +12,4 @@ Layout/LineLength:
   Max: 100
 
 Metrics/BlockLength:
-  AllowedMethods: ['describe', 'context']
-
+  AllowedMethods: ["describe", "context"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # master (unreleased)
 
+Deprecated:
+
+* ruby 3.3 is the minimum required ruby version
+
 Updates:
 
 * gems

--- a/gem_updater.gemspec
+++ b/gem_updater.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     'rubygems_mfa_required' => 'true'
   }
 
-  s.required_ruby_version = '>= 3.2'
+  s.required_ruby_version = '>= 3.3'
 
   s.add_dependency 'bundler',  '~> 4.0'
   s.add_dependency 'json',     '~> 2.6'


### PR DESCRIPTION
It reached [End of Life][1].

[1]: https://www.ruby-lang.org/en/downloads/branches/#ruby-32