### PR TITLE
UPGRADE actions/checkout to v6

### DIFF
--- a/.github/workflows/ruby-gem.yml
+++ b/.github/workflows/ruby-gem.yml
@@ -3,7 +3,7 @@ name: 📦 Ruby Gem
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 permissions:
   contents: read
@@ -17,19 +17,19 @@ jobs:
       packages: write
 
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby 4.0
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 4.0
+      - uses: actions/checkout@v6
+      - name: Set up Ruby 4.0
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 4.0
 
-    - name: Publish to RubyGems
-      run: |
-        mkdir -p $HOME/.gem
-        touch $HOME/.gem/credentials
-        chmod 0600 $HOME/.gem/credentials
-        printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-        gem build *.gemspec
-        gem push *.gem
-      env:
-        GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"
+      - name: Publish to RubyGems
+        run: |
+          mkdir -p $HOME/.gem
+          touch $HOME/.gem/credentials
+          chmod 0600 $HOME/.gem/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
+          gem build *.gemspec
+          gem push *.gem
+        env:
+          GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_AUTH_TOKEN}}"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -4,39 +4,39 @@ on: push
 
 permissions:
   contents: read
-  
+
 jobs:
   test:
     name: 🧪 Test (ruby ${{ matrix.ruby }})
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['3.2', '3.3', '3.4', '4.0']
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby ${{ matrix.ruby }}
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby }}
-        bundler-cache: true # 'bundle install' and cache gems
-    - name: Run tests
-      run: bundle exec rspec --format progress
+      - uses: actions/checkout@v6
+      - name: Set up Ruby ${{ matrix.ruby }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # 'bundle install' and cache gems
+      - name: Run tests
+        run: bundle exec rspec --format progress
 
-    - name: Report coverage
-      uses: codacy/codacy-coverage-reporter-action@v1
-      with:
-        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: coverage/coverage.xml
+      - name: Report coverage
+        uses: codacy/codacy-coverage-reporter-action@v1
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage/coverage.xml
 
   lint:
     name: 🧹 Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Ruby 4.0
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 4.0
-        bundler-cache: true # 'bundle install' and cache gems
-    - name: Lint
-      run: make lint
+      - uses: actions/checkout@v6
+      - name: Set up Ruby 4.0
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 4.0
+          bundler-cache: true # 'bundle install' and cache gems
+      - name: Lint
+        run: make lint


### PR DESCRIPTION
GitHub is dropping support for actions running on node 20. This patch is bumping `actions/checkout` to the latest version, running on node 24.