### PR TITLE
FIX simplecov setup

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,4 @@
 --color
+--require simplecov_setup
 --require spec_helper
 --format documentation

--- a/spec/simplecov_setup.rb
+++ b/spec/simplecov_setup.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+require 'simplecov'
+require 'simplecov-cobertura'
+
+SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
+
+SimpleCov.start

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,12 +1,6 @@
 # frozen_string_literal: true
 
 require 'gem_updater'
-require 'simplecov'
-require 'simplecov-cobertura'
-
-SimpleCov.formatter = SimpleCov::Formatter::CoberturaFormatter
-
-SimpleCov.start
 
 Dir["#{File.expand_path('support', __dir__)}/*.rb"].each { |file| require file }
 


### PR DESCRIPTION
`simplecov` must be started before requiring application code. Otherwise coverage is empty.